### PR TITLE
Fix documentation of blockCutTree

### DIFF
--- a/Codigo/Grafos/blockCutTree.cpp
+++ b/Codigo/Grafos/blockCutTree.cpp
@@ -11,8 +11,8 @@
 // criadas apos a remocao de i do grafo g
 // Se art[i] >= 1, i eh ponto de articulacao
 // 
-// Para todo i <= blocks.size()
-// blocks[i] eh uma componente 2-vertce-conexa maximal
+// Para todo i < blocks.size()
+// blocks[i] eh uma componente 2-vertice-conexa maximal
 // edgblocks[i] sao as arestas do bloco i
 // tree[i] eh um vertice da arvore que corresponde ao bloco i
 // 


### PR DESCRIPTION
A documentação  original afirma que todos os índices <= blocks.size() são correspondentes a componentes 2 conexas, mas são os índices estritamente menores, o que pode ser confirmado nesse trecho:
```cpp
tree.resize(blocks.size());
for (int i = 0; i < g.size(); i++) if (art[i]) 
    pos[i] = tree.size(), tree.emplace_back();
```