### PR TITLE
Opções de customização no LaTeX

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ O *theoretical guide* (documento com teoremas, identidades e informações teór
 
 Link para o latex do theoretical: [link](https://github.com/brunomaletta/Biblioteca/blob/master/theoretical/theoretical.tex).
 
-#### Atualizar o PDF
+#### Atualizar os PDFs
 
 <details>
 <summary>Detalhes</summary>
 
-Para atualizar o PDF primeiro instale o latex executando 
+Para atualizar os PDFs primeiro instale o latex executando
 ```
 sudo apt install texlive-full
 ```
-O pdf é gerado usando a ferramenta [rubber](https://gitlab.com/latex-rubber/rubber). Para baixá-la execute:
+O pdf da biblioteca é gerado usando a ferramenta [rubber](https://gitlab.com/latex-rubber/rubber). Para baixá-la execute:
 
 ```
 sudo apt install rubber
@@ -38,12 +38,18 @@ cd latex
 ./getlatex.sh
 ```
 
-Para atualizar o PDF do *Theoretical*: (o último comando remove os arquivos auxiliares)
+##### Customização
+
+Caso queira customizar o nome do time, integrantes e universidade, basta definir as seguintes variáveis de ambiente:
+
+- `TEAMNAME`: nome do time (default: `Xerebêlerebébis`)
+- `MEMBERS`: lista de membros (default: `Emanuel Silva, Bruno Monteiro \\& Rafael Grandsire`)
+- `UNIVERSITY`: universidade (default: `UFMG`)
+
+Por exemplo, o comando abaixo compila os PDFs customizando as três variáveis para outros valores:
 
 ```
-cd theoretical
-latexmk -pdf theoretical -outdir=../pdf
-latexmk -pdf theoretical -outdir=../pdf -c
+TEAMNAME="Amigos Pessoais" MEMBERS="Laila Melo, Luis Higino \\& Thiago Assis" UNIVERSITY="HGH" ./getlatex.sh 
 ```
 
 </details>

--- a/latex/comeco.tex
+++ b/latex/comeco.tex
@@ -10,6 +10,8 @@
 \usepackage{graphicx}
 \addtolength{\parskip}{.5\baselineskip}
 
+\input{env}
+
 %aqui comeca o que eu fiz de verdade, o resto veio e eu to com medo de tirar
 \usepackage{xcolor}
 \usepackage{listings} %biblioteca pro codigo
@@ -50,8 +52,8 @@ basicstyle=\ttfamily\footnotesize, % fonte
 	{~}{$\sim$}{1} % ~ bonitinho
 }
 
-\title{teambrbr002 \\ UFMG}
-\author{Emanuel Silva, Felipe Mota e Kaio Vieira}
+\title{\teamname \\ \teamuni}
+\author{\teammembers}
 
 
 \begin{document}

--- a/latex/getlatex.sh
+++ b/latex/getlatex.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# Provide default values
+: ${TEAMNAME:="Xerebêlerebébis"}
+: ${MEMBERS:="Emanuel Silva, Bruno Monteiro \\& Rafael Grandsire"}
+: ${UNIVERSITY:="UFMG"}
+
+cat > env.tex <<EOF
+\def\teamname{$TEAMNAME}
+\def\teammembers{$MEMBERS}
+\def\teamuni{$UNIVERSITY}
+EOF
+
 g++ -std=c++17 -o getlatex getlatex.cpp -O2
 ./getlatex $1 > biblioteca.tex
 rubber -d biblioteca
@@ -7,3 +18,10 @@ mv biblioteca.pdf ../pdf
 rm tmp.cpp
 rm getlatex biblioteca.aux biblioteca.toc biblioteca.out
 rm -f biblioteca.rubbercache
+
+pushd ../theoretical
+latexmk -pdf theoretical -outdir=../pdf
+latexmk -pdf theoretical -outdir=../pdf -c
+popd
+
+rm env.tex

--- a/theoretical/config.tex
+++ b/theoretical/config.tex
@@ -1,8 +1,10 @@
 \documentclass[10pt, twocolumn]{article}
 \usepackage[utf8]{inputenc}
 %Gummi|065|=)
-\title{\vspace{-2cm}\textbf{Theoretical Guide\\Torcida Pão de Alho™\\UFMG}}
-\author{Gabriel Lucas, Kaio Vieira \& Gustavo Cruz}
+\input{../latex/env}
+
+\title{\vspace{-2cm}\textbf{Theoretical Guide\\ \teamname \\ \teamuni}}
+\author{\teammembers}
 \date{}
 
 \usepackage[english]{babel}

--- a/theoretical/theoretical.tex
+++ b/theoretical/theoretical.tex
@@ -3,7 +3,7 @@
 \begin{document}
 
 \maketitle
-\rhead{UFMG - Torcida Pão de Alho™}
+\rhead{\teamuni\quad -\quad\teamname}
 \lhead{Theoretical Guide}
 \begin{flushleft}
 


### PR DESCRIPTION
Adiciona a opção de customizar o nome do time, lista de integrantes e universidade por meio de variáveis de ambiente, por exemplo:
```bash
TEAMNAME="Amigos Pessoais" MEMBERS="Laila Melo, Luis Higino \\& Thiago Assis" UNIVERSITY="HGH" ./getlatex.sh 

```
Isso facilita, por exemplo, um coach imprimir 10 bibliotecas diferentes na véspera de uma competição.
O `README.md` foi atualizado para ensinar como utilizar a customização. Para usar dessas mesmas opções, a compilação do Theoretical foi adicionada ao `getlatex.sh`.